### PR TITLE
serialize Custom errors

### DIFF
--- a/wary/src/error/mod.rs
+++ b/wary/src/error/mod.rs
@@ -133,7 +133,7 @@ impl Error {
 	}
 
 	#[cfg(feature = "alloc")]
-	pub(crate) fn message(&self) -> Option<Cow<str>> {
+	pub(crate) fn message(&self) -> Option<Cow<'_, str>> {
 		Some(match self {
 			Self::Alphanumeric(error) => error.message().into(),
 			Self::Ascii(error) => error.message().into(),

--- a/wary/src/error/mod.rs
+++ b/wary/src/error/mod.rs
@@ -59,7 +59,6 @@ pub enum Error {
 	#[error(transparent)]
 	Time(#[from] rule::time::Error),
 	#[error("{code}")]
-	#[cfg_attr(feature = "serde", serde(skip_serializing))]
 	Custom {
 		code: &'static str,
 		#[cfg(feature = "alloc")]


### PR DESCRIPTION
This is definitely useful to serialize custom errors!

Moreover, Report serialization try to serialize all errors, including Custom ones, which leads to a serialization error due to the skip_serialization flag (I suppose serde implementation really skip these marked fields without trying to serialize them).